### PR TITLE
Modernise flight recorder

### DIFF
--- a/plugins/diagnostics/html/jfr.html
+++ b/plugins/diagnostics/html/jfr.html
@@ -4,17 +4,6 @@
        hawtio-auto-columns=".jfr-column">
 
     <div class="jfr-column">
-      <div class="alert alert-warning alert-dismissable" ng-show="!jfrEnabled && isMessageVisible('jfrShowUnlockWarning')">
-        <button type="button"
-           class="close"
-           data-dismiss="alert"
-           aria-hidden="true" ng-click="closeMessageForGood('jfrShowUnlockWarning')" ><span class="pficon pficon-close"></span></button>
-        <span class="pficon pficon-warning-triangle-o"></span>
-        <strong>Please note:</strong> Running Java Flight Recorder on
-        production systems requires a <a
-        href="http://www.oracle.com/technetwork/java/javaseproducts/overview/index.html"
-        class="alert-link">license</a>.
-      </div>
       <div class="alert alert-info alert-dismissable" ng-show="isMessageVisible('jfrShowJcmd')">
         <button type="button"
                 class="close"

--- a/plugins/diagnostics/html/jfr.html
+++ b/plugins/diagnostics/html/jfr.html
@@ -224,13 +224,8 @@
         <td>{{aRecording.time | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
         <td ng-if="!!aRecording.file"><a href="file://{{aRecording.file}}">{{aRecording.file}}</a></td>
         <td ng-if="aRecording.canDownload">
-          <button class="recorderButton btn"
-                  title="Download recording"
-                  ng-class="raisedButton"
-                  tooltip="Dump {{jfrSettings.name}} to disk"
-                  ng-click="downloadRecording(aRecording.number)">
-            <i class="pficon-save fa-1x"></i>
-          </button>
+          <a href="{{aRecording.downloadLink}}" class="pficon-save fa-1x" target="_blank" download="recording{{aRecording.number}}.jfr">
+          </a>
         </td>
       </tr>
     </table>

--- a/plugins/diagnostics/html/jfr.html
+++ b/plugins/diagnostics/html/jfr.html
@@ -216,13 +216,22 @@
         <th>Rec#</th>
         <th>Size</th>
         <th>Time</th>
-        <th>File</th>
+        <th>File/Download</th>
       </tr>
       <tr ng-repeat="aRecording in recordings">
         <td>{{aRecording.number}}</td>
         <td>{{aRecording.size}}</td>
         <td>{{aRecording.time | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
-        <td><a href="file://{{aRecording.file}}">{{aRecording.file}}</a></td>
+        <td ng-if="!!aRecording.file"><a href="file://{{aRecording.file}}">{{aRecording.file}}</a></td>
+        <td ng-if="aRecording.canDownload">
+          <button class="recorderButton btn"
+                  title="Download recording"
+                  ng-class="raisedButton"
+                  tooltip="Dump {{jfrSettings.name}} to disk"
+                  ng-click="downloadRecording(aRecording.number)">
+            <i class="pficon-save fa-1x"></i>
+          </button>
+        </td>
       </tr>
     </table>
 

--- a/plugins/diagnostics/html/jfr.html
+++ b/plugins/diagnostics/html/jfr.html
@@ -50,8 +50,7 @@
           <div class="casetteLabel">
             {{jfrStatus}}
             <div class="notLabel">
-              <div class="wrapCog"
-                   ng-class="{'spinning': isRunning}">
+              <div class="wrapCog">
                 <svg role="img"
                      aria-label="cassette wheel"
                      xmlns="http://www.w3.org/2000/svg"
@@ -99,7 +98,6 @@
                 </svg>
               </div>
               <div class="wrapCog"
-                   ng-class="{'spinning': isRunning}"
                    id="rightCogWrapper">
                 <svg role="img"
                      aria-label="cassette wheel"
@@ -204,7 +202,8 @@
           <div simple-form
                name="jfrForm"
                data="formConfig"
-               entity="jfrSettings"></div>
+               entity="jfrSettings">
+              </div>
 
         </dd>
       </dl>

--- a/plugins/diagnostics/less/diagnostics.less
+++ b/plugins/diagnostics/less/diagnostics.less
@@ -51,6 +51,28 @@
   animation-timing-function: linear;
 }
 
+@-webkit-keyframes spin {
+  from {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+@keyframes spin {
+  from {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
+  }
+  to {
+    -webkit-transform: rotate(359deg);
+    transform: rotate(359deg);
+  }
+}
+
+
 .wrapCog {
   width: 50px;
   height: 50px;

--- a/plugins/diagnostics/ts/diagnostics-jfr.controller.ts
+++ b/plugins/diagnostics/ts/diagnostics-jfr.controller.ts
@@ -29,6 +29,34 @@ namespace Diagnostics {
     ];
   }
 
+  function updateSettingsFromCurrent(scopeSettings: JfrSettings,  currentConfig: Map<string,string>, currentRecordingNumber: number) : void {
+    scopeSettings.dumpOnExit=currentConfig['dumpOnExit'] === "true";
+    scopeSettings.filename=null;
+    scopeSettings.name=currentConfig['name']
+    scopeSettings.recordingNumber=""+currentRecordingNumber;
+    if ( currentConfig['duration'] != "0" ) {
+      scopeSettings.limitType="duration";
+      scopeSettings.limitValue=currentConfig['duration'];
+    } 
+    if (currentConfig['maxSize'] != "0") {
+      scopeSettings.limitType="maxsize";
+      scopeSettings.limitValue=currentConfig['maxSize'];
+    }
+  } 
+
+  function settingsToJfrOptions(settings: JfrSettings) {
+    var options = {
+      "name": "" + settings.name,
+      "dumpOnExit": "" + settings.dumpOnExit
+    }
+    if ( settings.limitType === "duration") {
+      options['duration'] = settings.limitValue;
+    } else if( settings.limitType === "maxsize") {
+      options['maxSize'] = settings.limitValue;
+    }
+    return options;
+  }
+
   export interface JfrSettings {
     limitType: string;
     limitValue: string;
@@ -43,6 +71,23 @@ namespace Diagnostics {
     size: string;
     file: string;
     time: number;
+    canDownload: boolean;
+  }
+
+  export interface RecordingFromJfrBean {
+    destination: string;
+    maxSize: number;
+    duration: number;
+    size: number;
+    maxAge: number;
+    toDisk: boolean;
+    name: string;
+    startTime: number;
+    stopTime: number;
+    id: number;
+    state: string;
+    dumpOnExit: boolean;
+    settings: Map<string,string>;
   }
 
   export interface JfrControllerScope extends ng.IScope {
@@ -55,6 +100,7 @@ namespace Diagnostics {
     startRecording: () => void;
     stopRecording: () => void;
     dumpRecording: () => void;
+    downloadRecording: (rec: number) => void;
     formConfig: Forms.FormConfiguration;
     recordings: Array<Recording>;
     pid: string;
@@ -66,158 +112,231 @@ namespace Diagnostics {
     closeMessageForGood: (key: string) => void;
     isMessageVisible: (key: string) => boolean;
   }
-
+  
+  
   export function DiagnosticsJfrController($scope: JfrControllerScope, $location: ng.ILocationService,
     workspace: Jmx.Workspace, jolokia: Jolokia.IJolokia, localStorage: Storage, diagnosticsService: DiagnosticsService) {
-    'ngInject';
-
-    $scope.forms = {};
-    $scope.pid = diagnosticsService.findMyPid($scope.pageTitle);
-    $scope.recordings = [];
-    $scope.settingsVisible = false;
-
-    $scope.jfrSettings = {
-      limitType: 'unlimited',
-      limitValue: '',
-      name: '',
-      dumpOnExit: true,
-      recordingNumber: '',
-      filename: ''
-    };
-
-    $scope.formConfig = <Forms.FormConfiguration>{
-      properties: <Forms.FormProperties>{
-        name: <Forms.FormElement>{
-          type: "java.lang.String",
-          tooltip: "Name for this connection",
-          "input-attributes": {
-            "placeholder": "Recording name (optional)..."
-          }
-        },
-        limitType: <Forms.FormElement>{
-          type: "java.lang.String",
-          tooltip: "Duration if any",
-          enum: ['unlimited', 'duration', 'maxsize']
-        },
-        limitValue: <Forms.FormElement>{
-          type: "java.lang.String",
-          tooltip: "Limit value. duration: [val]s/m/h, maxsize: [val]kB/MB/GB",
-          required: false,
-          "input-attributes": {
-            "ng-show": "jfrSettings.limitType != 'unlimited'"
-          }
-        },
-        dumpOnExit: <Forms.FormElement>{
-          type: "java.lang.Boolean",
-          tooltip: "Automatically dump recording on VM exit"
-        },
-        filename: <Forms.FormElement>{
-          type: "java.lang.String",
-          tooltip: "Filename",
-          "input-attributes": {
-            "placeholder": "Specify file name *.jfr (optional)..."
-          }
-        },
-      }
-    };
-
-    $scope.unlock = () => {
-      executeDiagnosticFunction('vmUnlockCommercialFeatures()', 'VM.unlock_commercial_features', [], null);
-    };
-
-    $scope.startRecording = () => {
-      if ($scope.isRecording) {//this means that there is a stopped recording, clear state before starting the next
-        $scope.jfrSettings.name = null;
-        $scope.jfrSettings.filename = null;
-      }
-      executeDiagnosticFunction('jfrStart([Ljava.lang.String;)', 'JFR.start', [buildStartParams($scope.jfrSettings)], null);
-    };
-
-    $scope.dumpRecording = () => {
-
-      executeDiagnosticFunction('jfrDump([Ljava.lang.String;)', 'JFR.dump',
-        [buildDumpParams($scope.jfrSettings)], (response) => {
-
-          const matches = splitResponse(response);
-          Diagnostics.log.debug("response: " + response
-            + " split: " + matches + "split2: "
-            + matches);
-          if (matches) {
-            const recordingData = {
-              number: matches[1],
-              size: matches[2],
-              file: matches[3],
-              time: Date.now()
-            };
-            Diagnostics.log.debug("data: "
-              + recordingData);
-            addRecording(recordingData, $scope.recordings);
-          }
-
-        });
-
-
-    };
-    $scope.closeMessageForGood = (key: string) => {
-      localStorage[key] = "false";
-    };
-
-    $scope.isMessageVisible = (key: string) => {
-      return localStorage[key] !== "false";
-    };
-
-    $scope.stopRecording = () => {
-      const name = $scope.jfrSettings.name;
-      $scope.jfrSettings.filename = '';
-      $scope.jfrSettings.name = '';
-      executeDiagnosticFunction('jfrStop([Ljava.lang.String;)', 'JFR.stop',
-        ['name="' + name + '"'], null);
-    };
-
-    $scope.toggleSettingsVisible = () => {
-      $scope.settingsVisible = !$scope.settingsVisible;
-      Core.$apply($scope);
-    };
-
-    Core.register(jolokia, $scope, [{
-      type: 'exec',
-      operation: 'jfrCheck([Ljava.lang.String;)',
-      mbean: 'com.sun.management:type=DiagnosticCommand',
-      arguments: ['']
-    }], Core.onSuccess(render));
-
-
-    function render(response) {
-      let statusString = response.value;
-      $scope.jfrEnabled = statusString.indexOf("not enabled") == -1;
-      $scope.isRunning = statusString.indexOf("(running)") > -1;
-      $scope.isRecording = $scope.isRunning || statusString.indexOf("(stopped)") > -1;
-      if ((statusString.indexOf("Use JFR.") > -1 || statusString
-        .indexOf("Use VM.") > -1)
-        && $scope.pid) {
-        statusString = statusString.replace("Use ",
-          "Use command line: jcmd " + $scope.pid + " ");
-      }
-      $scope.jfrStatus = statusString;
-      if ($scope.isRecording) {
-        let regex = /recording=(\d+) name="(.+?)"/g;
-        if ($scope.isRunning) { //if there are several recordings (some stopped), make sure we parse the running one
-          regex = /recording=(\d+) name="(.+?)".+?\(running\)/g;
+      'ngInject';
+      
+      //common definitions / setup
+      $scope.jfrSettings = {
+        limitType: 'unlimited',
+        limitValue: '',
+        name: '',
+        dumpOnExit: true,
+        recordingNumber: '',
+        filename: ''
+      };
+      $scope.forms = {};
+      $scope.recordings = [];
+      $scope.settingsVisible = false;
+      $scope.toggleSettingsVisible = () => {
+        $scope.settingsVisible = !$scope.settingsVisible;
+        Core.$apply($scope);
+      };
+      $scope.formConfig = <Forms.FormConfiguration>{
+        properties: <Forms.FormProperties>{
+          name: <Forms.FormElement>{
+            type: "java.lang.String",
+            tooltip: "Name for this connection",
+            "input-attributes": {
+              "placeholder": "Recording name (optional)..."
+            }
+          },
+          limitType: <Forms.FormElement>{
+            type: "java.lang.String",
+            tooltip: "Duration if any",
+            enum: ['unlimited', 'duration', 'maxsize']
+          },
+          limitValue: <Forms.FormElement>{
+            type: "java.lang.String",
+            tooltip: "Limit value. duration: [val]s/m/h, maxsize: [val]kB/MB/GB",
+            required: false,
+            "input-attributes": {
+              "ng-show": "jfrSettings.limitType != 'unlimited'"
+            }
+          },
+          dumpOnExit: <Forms.FormElement>{
+            type: "java.lang.Boolean",
+            tooltip: "Automatically dump recording on VM exit"
+          },
+          filename: <Forms.FormElement>{
+            type: "java.lang.String",
+            tooltip: "Filename",
+            "input-attributes": {
+              "placeholder": "Specify file name *.jfr (optional)..."
+            }
+          },
         }
-
-        const parsed = regex.exec(statusString);
-        $scope.jfrSettings.recordingNumber = parsed[1];
-        $scope.jfrSettings.name = parsed[2];
-        const parsedFilename = statusString.match(/filename="(.+)"/);
-        if (parsedFilename && parsedFilename[1]) {
-          $scope.jfrSettings.filename = parsedFilename[1];
-        } else {
-          $scope.jfrSettings.filename = 'recording' + parsed[1] + '.jfr';
-        }
-
+      };
+      const jfrMbean = diagnosticsService.flightRecorderMBean();
+      if(jfrMbean) {
+        configureScopeForJfr($scope, jolokia, jfrMbean);
+      } else {
+        configureScopeForDiagnosticCommand($scope, jolokia, localStorage);
       }
+      Core.register(jolokia, $scope, [{
+        type: 'exec',
+        operation: 'jfrCheck([Ljava.lang.String;)',
+        mbean: 'com.sun.management:type=DiagnosticCommand',
+        arguments: ['']
+      }], Core.onSuccess(render));
+  
+  
+      function render(response) {
+        let statusString = response.value;
+        $scope.jfrEnabled = statusString.indexOf("not enabled") == -1;
+        $scope.isRunning = statusString.indexOf("(running)") > -1;
+        $scope.isRecording = $scope.isRunning || statusString.indexOf("(stopped)") > -1;
+        if ((statusString.indexOf("Use JFR.") > -1 || statusString
+          .indexOf("Use VM.") > -1)
+          && $scope.pid) {
+          statusString = statusString.replace("Use ",
+            "Use command line: jcmd " + $scope.pid + " ");
+        }
+        $scope.jfrStatus = statusString;
+        if ($scope.isRecording) {
+          let regex = /ecording.(\d+):* name="*(.+?)"*/g;
+          if ($scope.isRunning) { //if there are several recordings (some stopped), make sure we parse the running one
+            regex = /ecording.(\d+):* name="*(.+?)"*.+?\(running\)/g;
+          }
+  
+          const parsed = regex.exec(statusString);
+          $scope.jfrSettings.recordingNumber = parsed[1];
+          $scope.jfrSettings.name = parsed[2];
+          const parsedFilename = statusString.match(/filename="(.+)"/);
+          if (parsedFilename && parsedFilename[1]) {
+            $scope.jfrSettings.filename = parsedFilename[1];
+          } else {
+            $scope.jfrSettings.filename = 'recording' + parsed[1] + '.jfr';
+          }
+  
+        }
       Core.$apply($scope);
     }
+
+    //Use Flight Recorder MBean for controlling flight recorder loosely inspired by: 
+    //https://github.com/openjdk/jmc7/blob/master/application/org.openjdk.jmc.rjmx.services.jfr/src/main/java/org/openjdk/jmc/rjmx/services/jfr/internal/FlightRecorderServiceV2.java
+    function configureScopeForJfr(scope: JfrControllerScope, 
+      jolokia: Jolokia.IJolokia, jfrMBean: string) {
+        var currentRecordingNumber=-1;
+        //these are not not neccesary for jfr
+        scope.unlock = () => {};
+        scope.isMessageVisible = (key) => {return false};
+        scope.closeMessageForGood = (key) => {};
+        scope.jfrEnabled = true;
+        figureOutRecordingsAndSettings();
+
+        scope.startRecording = () => {
+
+          jolokia.execute(jfrMBean, "setRecordingOptions", currentRecordingNumber, settingsToJfrOptions(scope.jfrSettings), {});
+          jolokia.execute(jfrMBean, "startRecording", currentRecordingNumber);
+          scope.isRecording=true;
+        };
+    
+        scope.stopRecording = () => {
+    
+          jolokia.execute(jfrMBean, "stopRecording", currentRecordingNumber);
+          figureOutRecordingsAndSettings();
+    
+        };
+        scope.dumpRecording = () => {
+          scope.downloadRecording(currentRecordingNumber);
+        };
+
+        scope.downloadRecording = (recordingNumber: number) => {
+          jolokia.execute(jfrMBean, "openStream", recordingNumber);
+
+        }
+        Core.$apply(scope);
+
+      function figureOutRecordingsAndSettings() {
+        const existingRecordings: RecordingFromJfrBean[] = getExistingRecordings(jolokia, jfrMBean, scope);
+        if (existingRecordings.length == 0 || existingRecordings[existingRecordings.length - 1].state === "STOPPED") {
+          currentRecordingNumber = jolokia.execute(jfrMBean, "newRecording").value;
+        }
+        else {
+          currentRecordingNumber = existingRecordings[existingRecordings.length - 1].id;
+        }
+        updateSettingsFromCurrent(scope.jfrSettings, jolokia.execute(jfrMBean, "getRecordingOptions", currentRecordingNumber), currentRecordingNumber);
+      }
+      }
+     
+
+  function getExistingRecordings(jolokia: Jolokia.IJolokia, jfrMBean: string, scope: JfrControllerScope): RecordingFromJfrBean[] {
+    const existingRecordings : RecordingFromJfrBean[] = jolokia.getAttribute(jfrMBean, "Recordings");
+    scope.recordings=[];
+    for (let index = 0; index < existingRecordings.length; index++) {
+      const element = existingRecordings[index];
+      if(element.state === "STOPPED") {
+        scope.recordings.push({
+          number: "" + element.id,
+          size: element.size + " b",
+          file: null,
+          time: element.stopTime,
+          canDownload: true});
+      }
+    }
+    return existingRecordings;
+  }
+
+    function configureScopeForDiagnosticCommand(scope: JfrControllerScope, 
+       jolokia: Jolokia.IJolokia, localStorage: Storage) {
+      scope.pid = findMyPid();
+  
+      scope.unlock = () => {
+        executeDiagnosticFunction('vmUnlockCommercialFeatures()', 'VM.unlock_commercial_features', [], null);
+      };
+  
+      scope.startRecording = () => {
+        if (scope.isRecording) {//this means that there is a stopped recording, clear state before starting the next
+          scope.jfrSettings.name = null;
+          scope.jfrSettings.filename = null;
+        }
+        executeDiagnosticFunction('jfrStart([Ljava.lang.String;)', 'JFR.start', [buildStartParams(scope.jfrSettings)], null);
+      };
+  
+      scope.dumpRecording = () => {
+  
+        executeDiagnosticFunction('jfrDump([Ljava.lang.String;)', 'JFR.dump',
+          [buildDumpParams(scope.jfrSettings)], (response) => {
+  
+            const matches = splitResponse(response);
+            Diagnostics.log.debug("response: " + response
+              + " split: " + matches + "split2: "
+              + matches);
+            if (matches) {
+              const recordingData = {
+                number: matches[1],
+                size: matches[2],
+                file: matches[3],
+                time: Date.now(),
+                canDownload : false
+              };
+              Diagnostics.log.debug("data: "
+                + recordingData);
+              addRecording(recordingData, scope.recordings);
+            }
+          });  
+      };
+      scope.closeMessageForGood = (key: string) => {
+        localStorage[key] = "false";
+      };
+  
+      scope.isMessageVisible = (key: string) => {
+        return localStorage[key] !== "false";
+      };
+  
+      scope.stopRecording = () => {
+        const name = scope.jfrSettings.name;
+        scope.jfrSettings.filename = '';
+        scope.jfrSettings.name = '';
+        executeDiagnosticFunction('jfrStop([Ljava.lang.String;)', 'JFR.stop',
+          ['name="' + name + '"'], null);
+      };
+  
+    }
+  
 
     function addRecording(recording: Recording, recordings: Array<Recording>) {
       for (let i = 0; i < recordings.length; i++) {
@@ -245,8 +364,8 @@ namespace Diagnostics {
 
     function executeDiagnosticFunction(operation: string, jcmd: string, arguments, callback) {
       Diagnostics.log.debug(Date.now() + " Invoking operation "
-        + operation + " with arguments" + arguments + " settings: " + JSON.stringify($scope.jfrSettings));
-      $scope.jcmd = 'jcmd ' + $scope.pid + ' ' + jcmd + ' ' + showArguments(arguments);
+        + operation + " with arguments" + arguments + " settings: " + JSON.stringify(scope.jfrSettings));
+      scope.jcmd = 'jcmd ' + scope.pid + ' ' + jcmd + ' ' + showArguments(arguments);
       jolokia.request([{
         type: "exec",
         operation: operation,
@@ -266,7 +385,7 @@ namespace Diagnostics {
           if (callback) {
             callback(response.value);
           }
-          Core.$apply($scope);
+          Core.$apply(scope);
         }
       }, {
         error: function (response) {
@@ -274,6 +393,17 @@ namespace Diagnostics {
             + operation + " failed", response);
         }
       }));
+    }
+    function findMyPid() {
+      //snatch PID from window title
+      const name = jolokia.getAttribute('java.lang:type=Runtime', 'Name');
+      const regex = /(\d+)@/g;
+      const pid = regex.exec(name);
+      if (pid && pid[1]) {
+        return pid[1];
+      } else {
+        return null;
+      }
     }
 
   }

--- a/plugins/diagnostics/ts/diagnostics-jfr.controller.ts
+++ b/plugins/diagnostics/ts/diagnostics-jfr.controller.ts
@@ -72,6 +72,7 @@ namespace Diagnostics {
     file: string;
     time: number;
     canDownload: boolean;
+    downloadLink: string;
   }
 
   export interface RecordingFromJfrBean {
@@ -115,7 +116,7 @@ namespace Diagnostics {
   
   
   export function DiagnosticsJfrController($scope: JfrControllerScope, $location: ng.ILocationService,
-    workspace: Jmx.Workspace, jolokia: Jolokia.IJolokia, localStorage: Storage, diagnosticsService: DiagnosticsService) {
+    workspace: Jmx.Workspace, jolokia: Jolokia.IJolokia, localStorage: Storage, diagnosticsService: DiagnosticsService, jolokiaUrl:string) {
       'ngInject';
       
       //common definitions / setup
@@ -255,7 +256,8 @@ namespace Diagnostics {
               size: lastRecording.size + " b",
               file: null,
               time: lastRecording.stopTime,
-              canDownload: true});
+              canDownload: true,
+              downloadLink: jolokiaUrl + "/exec/jdk.management.jfr:type=FlightRecorder/downloadRecording(long)/" + lastRecording.id});
           }
         }
         if(lastRecording) {
@@ -311,7 +313,8 @@ namespace Diagnostics {
                 size: matches[2],
                 file: matches[3],
                 time: Date.now(),
-                canDownload : false
+                canDownload : false,
+                downloadLink : null
               };
               Diagnostics.log.debug("data: "
                 + recordingData);
@@ -420,7 +423,7 @@ namespace Diagnostics {
         Diagnostics.log.debug("Diagnostic Operation "
           + operation + " was successful" + response.value);
         if (response.request.operation.indexOf("jfrCheck") > -1) {
-          render(response);
+//          render(response);
         } else {
           if (callback) {
             callback(response.value);

--- a/plugins/diagnostics/ts/diagnostics-jfr.controller.ts
+++ b/plugins/diagnostics/ts/diagnostics-jfr.controller.ts
@@ -262,6 +262,7 @@ namespace Diagnostics {
           while(true) {
             let value=jolokia.execute(jfrMBean, "readStream", streamId);
             if(Array.isArray(value)) {
+              //reuse buffer accross calls if possible 
               if(value.length != buffer.length) {
                 buffer=new Uint8Array(value.length);
               }
@@ -271,6 +272,7 @@ namespace Diagnostics {
             } else {
               break;
             }
+            //TODO: figure out how to get data over to the client.
           }
 
         }

--- a/plugins/diagnostics/ts/diagnostics.service.ts
+++ b/plugins/diagnostics/ts/diagnostics.service.ts
@@ -11,7 +11,7 @@ namespace Diagnostics {
 
     getTabs(): Nav.HawtioTab[] {
       const tabs = [];
-      if (this.hasDiagnosticFunction('jfrCheck')) {
+      if (this.hasDiagnosticFunction('jfrCheck') || this.flightRecorderMBean()) {
         tabs.push(new Nav.HawtioTab('Flight Recorder', '/diagnostics/jfr'));
       }
       if (this.hasDiagnosticFunction('gcClassHistogram')) {
@@ -32,15 +32,16 @@ namespace Diagnostics {
       return diagnostics && diagnostics.mbean && diagnostics.mbean.op && !!diagnostics.mbean.op[operation];
     }
 
-    findMyPid(title) {
-      //snatch PID from window title
-      const regex = /pid:(\d+)/g;
-      const pid = regex.exec(title);
-      if (pid && pid[1]) {
-        return pid[1];
+    public flightRecorderMBean() : string {
+      //varying names over different JVM versions, could potentially support jrockit as well, but not prioritizing
+      if(this.workspace.findMBeanWithProperties('jdk.management.jfr', {type: 'FlightRecorder'})) {
+        return 'jdk.management.jfr:type=FlightRecorder';
+      } else if (this.workspace.findMBeanWithProperties('jdk.jfr.management', {type: 'FlightRecorder'})) {
+        return 'jdk.jfr.management:type=FlightRecorder';
       } else {
         return null;
       }
+      
     }
 
   }


### PR DESCRIPTION
* Use dedicated FlightRecorder MBean for much more sound handling than parsing DiagnosticCommand
* Support downloading recordings as stream directly in browser
* Select default or profile settings (like Java mission control)
* Fix animation
Depends on https://github.com/hawtio/hawtio/pull/2669 for download to work

Will post a video that demonstrates the effect

Tested with embedded jetty and tomcat , Java 8 & 11-15