### PR TITLE
chore: updated spring-boot doc and Camel version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Do not use this flag when you are committing the compiled `.js` file, as it embe
 In order to support the latest Camel meta model in Camel plugin, you need to update the [camelModel.js](vendor/apache-camel/camelModel.js) with the latest `camel-catalog`. To do so, first update the Camel version in the `camel-model-generator` [pom.xml](vendor/apache-camel/pom.xml):
 
 ```
-    <version.org.apache.camel>2.23.0</version.org.apache.camel>
+    <version.org.apache.camel>3.14.2</version.org.apache.camel>
 ```
 then run the following yarn script:
 ```

--- a/plugins/spring-boot/doc/help.md
+++ b/plugins/spring-boot/doc/help.md
@@ -1,14 +1,18 @@
 ## Spring Boot
 
-The Spring Boot plugin provides the capability interact with [acutator](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) endpoints exposed by an application.
+The Spring Boot plugin provides the capability interact with [actuator](https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html) endpoints exposed by an application.
 
 ### Health
 
 Displays the current health status of the application together with details returned from any Spring Boot health checks.
 
+### Info
+
+Displays relevant information regarding the Spring boot application. It is the  output of the Info actuator endpoint.
+
 ### Loggers
 
-Lists all of the available loggers in the application. You can modify the level of a logger and the changes will take effect immediately.
+Lists all  the available loggers in the application. You can modify the level of a logger and the changes will take effect immediately.
 
 ### Trace
 


### PR DESCRIPTION
1. This is to update the current camel version mentioned in the projects [README](https://github.com/hawtio/hawtio-integration#readme) to `3.14.2` after the PR: https://github.com/hawtio/hawtio-integration/pull/138
2. The Spring boot doc needs to be updated as a new Endpoint `Info` has been added. Check PR: https://github.com/hawtio/hawtio-integration/pull/132. 