### PR TITLE
fix(diagnostics): Replace download link for Spring Boot apps

### DIFF
--- a/plugins/diagnostics/html/jfr.html
+++ b/plugins/diagnostics/html/jfr.html
@@ -210,8 +210,10 @@
         <td>{{aRecording.number}}</td>
         <td>{{aRecording.size}}</td>
         <td>{{aRecording.time | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
-        <td ng-if="!!aRecording.file"><a href="file://{{aRecording.file}}">{{aRecording.file}}</a></td>
-        <td ng-if="aRecording.canDownload">
+        <td ng-if="!aRecording.canDownload && !!aRecording.file"><a href="file://{{aRecording.file}}">{{aRecording.file}}</a></td>
+        <td ng-if="aRecording.canDownload && !!aRecording.file"><a href="{{aRecording.downloadLink}}" class="pficon-save fa-1x" target="_blank"></a></td>
+
+        <td ng-if="aRecording.canDownload && !aRecording.file">
           <a href="{{aRecording.downloadLink}}" class="pficon-save fa-1x" target="_blank" download="recording{{aRecording.number}}.jfr">
           </a>
         </td>

--- a/plugins/diagnostics/html/jfr.html
+++ b/plugins/diagnostics/html/jfr.html
@@ -211,7 +211,7 @@
         <td>{{aRecording.size}}</td>
         <td>{{aRecording.time | date: 'yyyy-MM-dd HH:mm:ss' }}</td>
         <td ng-if="!aRecording.canDownload && !!aRecording.file"><a href="file://{{aRecording.file}}">{{aRecording.file}}</a></td>
-        <td ng-if="aRecording.canDownload && !!aRecording.file"><a href="{{aRecording.downloadLink}}" class="pficon-save fa-1x" target="_blank"></a></td>
+        <td ng-if="aRecording.canDownload && !!aRecording.file"><a href="{{aRecording.downloadLink}}" target="_blank">Click to save to "{{aRecording.file}}"</a></td>
 
         <td ng-if="aRecording.canDownload && !aRecording.file">
           <a href="{{aRecording.downloadLink}}" class="pficon-save fa-1x" target="_blank" download="recording{{aRecording.number}}.jfr">


### PR DESCRIPTION
Due to an error when using Spring Boot apps together with
Hawtio version <2.15 the download link cannot be used the same way as
other mBean-enabled contexts.

Here, a workaround is implemented to save the Flight Recorder recording
on the host machine by clicking the download button. The recording will
be saved as: <recording id>.jfr.
The best approach would be to fix the error in the downloadRecording
implementation in the Hawtio backend, but that is for the time being
substantially more difficult.

Partially remediates #2724 in hawtio issue tracker https://github.com/hawtio/hawtio/issues/2724

---

This pull request should serve as inspiration for other ways to fix this problem.
Simple extensions include displaying the path for the saved file to the user instead of displaying the response from Jolokia execution of copyTo.