### PR TITLE
Hawtio console metrics shows free memory instead of used (amendment)

### DIFF
--- a/plugins/runtime/metrics/metrics.component.ts
+++ b/plugins/runtime/metrics/metrics.component.ts
@@ -47,14 +47,14 @@ namespace Runtime {
           let filterNumeric = this.$filter('number');
           let cpuLoad = filterNumeric(metrics.SystemCpuLoad * 100, 2);
           let loadAverage = filterNumeric(metrics.SystemLoadAverage, 2);
+          let memFree = this.formatBytes(metrics.FreePhysicalMemorySize);
           let memTotal = this.formatBytes(metrics.TotalPhysicalMemorySize);
-          let memUsed = this.formatBytes(metrics.TotalPhysicalMemorySize - metrics.FreePhysicalMemorySize);
           updateType = MetricType.SYSTEM;
 
           updates.push(this.metricsService.createMetric('Available processors', metrics.AvailableProcessors));
           updates.push(this.metricsService.createMetric('CPU load', cpuLoad, '%'));
           updates.push(this.metricsService.createMetric('Load average', loadAverage));
-          updates.push(this.metricsService.createUtilizationMetric('Memory used', memUsed[0], memTotal[0], memUsed[1]));
+          updates.push(this.metricsService.createUtilizationMetric('Free memory', memFree[0], memTotal[0], memFree[1]));
           updates.push(this.metricsService.createUtilizationMetric('File descriptors used', metrics.OpenFileDescriptorCount, metrics.MaxFileDescriptorCount));
           break;
         case 'java.lang:type=ClassLoading':


### PR DESCRIPTION
Runtime > Metrics > System shows "Used memory", but the value there displays free memory instead.

An amendment of https://github.com/hawtio/hawtio-integration/pull/166

Since it showed up the used memory could be calculated as _used = total - free_ (there are other hidden elements, such as chaced memory that are **not** available in the `metrics` object), we have to revert the changes and change the label instead.